### PR TITLE
feat: create relation tuple tables with added namespace config

### DIFF
--- a/internal/datastores/sql-store.go
+++ b/internal/datastores/sql-store.go
@@ -19,11 +19,11 @@ type SQLStore struct {
 
 func (s *SQLStore) SubjectSets(ctx context.Context, object ac.Object, relations ...string) ([]ac.SubjectSet, error) {
 
-	sqlbuilder := goqu.Dialect("postgres").From(object.Namespace).Select("user").Where(
+	sqlbuilder := goqu.Dialect("postgres").From(object.Namespace).Select("subject").Where(
 		goqu.Ex{
 			"object":   object.ID,
 			"relation": relations,
-			"user":     goqu.Op{"like": "_%%:_%%#_%%"},
+			"subject":  goqu.Op{"like": "_%%:_%%#_%%"},
 		},
 	)
 
@@ -63,7 +63,7 @@ func (s *SQLStore) RowCount(ctx context.Context, query ac.RelationTupleQuery) (i
 	).Where(goqu.Ex{
 		"object":   query.Object.ID,
 		"relation": query.Relations,
-		"user":     query.Subject.String(),
+		"subject":  query.Subject.String(),
 	})
 
 	sql, args, err := sqlbuilder.ToSQL()
@@ -103,7 +103,7 @@ func (s *SQLStore) ListRelationTuples(ctx context.Context, query *aclpb.ListRela
 
 	if query.GetSubject() != nil {
 		sqlbuilder = sqlbuilder.Where(goqu.Ex{
-			"user": query.GetSubject().String(),
+			"subject": query.GetSubject().String(),
 		})
 	}
 
@@ -149,7 +149,7 @@ func (s *SQLStore) TransactRelationTuples(ctx context.Context, tupleInserts []*a
 	}
 
 	for _, tuple := range tupleInserts {
-		sqlbuilder := goqu.Dialect("postgres").Insert(tuple.Namespace).Cols("object", "relation", "user").Vals(
+		sqlbuilder := goqu.Dialect("postgres").Insert(tuple.Namespace).Cols("object", "relation", "subject").Vals(
 			goqu.Vals{tuple.Object, tuple.Relation, tuple.Subject.String()},
 		).OnConflict(goqu.DoNothing())
 
@@ -184,7 +184,7 @@ func (s *SQLStore) TransactRelationTuples(ctx context.Context, tupleInserts []*a
 		sqlbuilder := goqu.Dialect("postgres").Delete(tuple.Namespace).Where(goqu.Ex{
 			"object":   tuple.Object,
 			"relation": tuple.Relation,
-			"user":     tuple.Subject.String(),
+			"subject":  tuple.Subject.String(),
 		})
 
 		sql, args, err := sqlbuilder.ToSQL()

--- a/internal/namespace-manager/postgres/manager.go
+++ b/internal/namespace-manager/postgres/manager.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/doug-martin/goqu/v9"
@@ -79,6 +80,18 @@ func (m *sqlNamespaceManager) AddConfig(ctx context.Context, cfg *aclpb.Namespac
 	}
 
 	_, err = txn.Exec(sql2, args2...)
+	if err != nil {
+		return err
+	}
+
+	stmt := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		object text,
+		relation text,
+		subject text,
+		PRIMARY KEY (object, relation, subject)
+	)`, cfg.Name)
+
+	_, err = txn.Exec(stmt)
 	if err != nil {
 		return err
 	}

--- a/internal/namespace.go
+++ b/internal/namespace.go
@@ -11,6 +11,7 @@ import (
 
 var ErrNamespaceAlreadyExists error = errors.New("The provided namespace already exists.")
 var ErrNamespaceDoesntExist error = errors.New("The provided namespace doesn't exist, please add it first.")
+var ErrNoLocalNamespacesDefined error = errors.New("No local namespace configs have been defined at this time.")
 
 var nsConfigSnapshotTimestampKey ctxKey
 


### PR DESCRIPTION
The changes herein add support to automatically provision a new table to store the relation tuples for a namespace when the namespace is first created.

Closes #2 