### PR TITLE
fix: disallow references to undefined relations and misc

### DIFF
--- a/api/openapiv2/authorizer/accesscontroller/v1alpha1/namespace_service.swagger.json
+++ b/api/openapiv2/authorizer/accesscontroller/v1alpha1/namespace_service.swagger.json
@@ -52,14 +52,15 @@
           "NamespaceConfigService"
         ]
       },
-      "post": {
-        "summary": "Adds a new namespace configuration. If the namespace already exists,\nan AlreadyExists status code is returned.",
-        "operationId": "NamespaceConfigService_AddConfig",
+      "put": {
+        "summary": "WriteConfig upserts a namespace configuration. If the namespace config already exists,\nthe existing one is overwritten.",
+        "description": "If the new namespace config removes an existing relation, there must not be any relation\ntuples that reference it. Otherwise a FAILED_PRECONDITION status is returned. To migrate\naway from a relation, please move all existing relation tuples referencing it over to the\nnew relation and then delete the old relation once all tuples have been migrated.",
+        "operationId": "NamespaceConfigService_WriteConfig",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1alpha1AddConfigResponse"
+              "$ref": "#/definitions/v1alpha1WriteConfigResponse"
             }
           },
           "default": {
@@ -75,46 +76,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1alpha1AddConfigRequest"
-            }
-          }
-        ],
-        "tags": [
-          "NamespaceConfigService"
-        ]
-      }
-    },
-    "/authorizer/access-controller/v1alpha1/namespace-configs/{namespace}": {
-      "post": {
-        "summary": "Upserts a relation for the given namespace config.",
-        "operationId": "NamespaceConfigService_WriteRelation",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/v1alpha1WriteRelationResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response.",
-            "schema": {
-              "$ref": "#/definitions/rpcStatus"
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/v1alpha1WriteRelationRequest"
+              "$ref": "#/definitions/v1alpha1WriteConfigRequest"
             }
           }
         ],
@@ -182,24 +144,6 @@
           }
         }
       }
-    },
-    "v1alpha1AddConfigRequest": {
-      "type": "object",
-      "properties": {
-        "config": {
-          "$ref": "#/definitions/v1alpha1NamespaceConfig"
-        }
-      },
-      "description": "The request for a NamespaceConfigService.AddConfig rpc."
-    },
-    "v1alpha1AddConfigResponse": {
-      "type": "object",
-      "properties": {
-        "snaptoken": {
-          "type": "string"
-        }
-      },
-      "description": "The response for a NamespaceConfigService.AddConfig rpc."
     },
     "v1alpha1ComputedSubjectset": {
       "type": "object",
@@ -282,21 +226,18 @@
         }
       }
     },
-    "v1alpha1WriteRelationRequest": {
+    "v1alpha1WriteConfigRequest": {
       "type": "object",
       "properties": {
-        "namespace": {
-          "type": "string"
-        },
-        "relation": {
-          "$ref": "#/definitions/v1alpha1Relation"
+        "config": {
+          "$ref": "#/definitions/v1alpha1NamespaceConfig"
         }
       },
-      "description": "The request for a NamespaceConfigService.WriteRelation rpc."
+      "description": "The request for a NamespaceConfigService.WriteConfig rpc."
     },
-    "v1alpha1WriteRelationResponse": {
+    "v1alpha1WriteConfigResponse": {
       "type": "object",
-      "description": "The response for a NamespaceConfigService.WriteRelation rpc."
+      "description": "The response for a NamespaceConfigService.WriteConfig rpc."
     }
   }
 }

--- a/api/protos/authorizer/accesscontroller/v1alpha1/namespace_service.proto
+++ b/api/protos/authorizer/accesscontroller/v1alpha1/namespace_service.proto
@@ -10,11 +10,16 @@ option go_package = "github.com/authorizer-tech/access-controller/genprotos/auth
 // The service to administer namespace configurations.
 service NamespaceConfigService {
 
-  // Adds a new namespace configuration. If the namespace already exists,
-  // an AlreadyExists status code is returned.
-  rpc AddConfig(AddConfigRequest) returns (AddConfigResponse) {
-      option (google.api.http) = {
-      post: "/authorizer/access-controller/v1alpha1/namespace-configs",
+  // WriteConfig upserts a namespace configuration. If the namespace config already exists,
+  // the existing one is overwritten.
+  //
+  // If the new namespace config removes an existing relation, there must not be any relation
+  // tuples that reference it. Otherwise a FAILED_PRECONDITION status is returned. To migrate
+  // away from a relation, please move all existing relation tuples referencing it over to the
+  // new relation and then delete the old relation once all tuples have been migrated.
+  rpc WriteConfig(WriteConfigRequest) returns (WriteConfigResponse) {
+    option (google.api.http) = {
+      put: "/authorizer/access-controller/v1alpha1/namespace-configs",
       body: "*"
     };
   }
@@ -25,24 +30,16 @@ service NamespaceConfigService {
       get: "/authorizer/access-controller/v1alpha1/namespace-configs"
     };
   }
-
-  // Upserts a relation for the given namespace config.
-  rpc WriteRelation(WriteRelationRequest) returns (WriteRelationResponse) {
-    option (google.api.http) = {
-      post: "/authorizer/access-controller/v1alpha1/namespace-configs/{namespace}",
-      body: "*"
-    };
-  }
 }
 
-// The request for a NamespaceConfigService.AddConfig rpc.
-message AddConfigRequest {
+// The request for a NamespaceConfigService.WriteConfig rpc.
+message WriteConfigRequest {
     NamespaceConfig config = 1;
 }
 
-// The response for a NamespaceConfigService.AddConfig rpc.
-message AddConfigResponse {
-    string snaptoken = 1;
+// The response for a NamespaceConfigService.WriteConfig rpc.
+message WriteConfigResponse {
+
 }
 
 // The request for a NamespaceConfigService.ReadConfig rpc.
@@ -56,17 +53,6 @@ message ReadConfigResponse {
     string namespace = 1;
     NamespaceConfig config = 2;
     string snaptoken = 3;
-}
-
-// The request for a NamespaceConfigService.WriteRelation rpc.
-message WriteRelationRequest {
-    string namespace = 1;
-    Relation relation = 2;
-}
-
-// The response for a NamespaceConfigService.WriteRelation rpc.
-message WriteRelationResponse {
-
 }
 
 message NamespaceConfig {

--- a/db/migrations/1_bootstrap_tables.down.sql
+++ b/db/migrations/1_bootstrap_tables.down.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS "namespace-relation-lookup";
 DROP TABLE IF EXISTS "changelog";
 DROP TABLE IF EXISTS "namespace-changelog";
 DROP TABLE IF EXISTS "namespace-configs";

--- a/db/migrations/1_bootstrap_tables.up.sql
+++ b/db/migrations/1_bootstrap_tables.up.sql
@@ -20,3 +20,10 @@ CREATE TABLE IF NOT EXISTS "changelog" (
     "timestamp" timestamp with time zone NOT NULL,
     PRIMARY KEY (namespace, operation, relationtuple, "timestamp")
 );
+
+CREATE TABLE IF NOT EXISTS "namespace-relation-lookup" (
+    namespace text NOT NULL,
+    relation text NOT NULL,
+    relationtuple text NOT NULL,
+    PRIMARY KEY (namespace, relation, relationtuple)
+);

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/bufbuild/buf v0.42.1
 	github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/cespare/xxhash v1.1.0
 	github.com/doug-martin/goqu/v9 v9.10.0
 	github.com/golang-migrate/migrate/v4 v4.14.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,9 @@ github.com/bufbuild/buf v0.42.1/go.mod h1:U6k2b3g7ZBL2d4iIH13fMZ3tml0yRuqsSe3Rvq
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72 h1:fUmDBbSvv1uOzo/t8WaxZMVb7BxJ8JECo5lGoR9c5bA=
 github.com/buraksezer/consistent v0.0.0-20191006190839-693edf70fd72/go.mod h1:OEE5igu/CDjGegM1Jn6ZMo7R6LlV/JChAkjfQQIRLpg=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
-github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/internal/namespace_test.go
+++ b/internal/namespace_test.go
@@ -407,7 +407,15 @@ func TestNamespaceConfigError_ToStatus(t *testing.T) {
 				Message: "some error",
 				Type:    NamespaceRelationUndefined,
 			},
-			output: status.New(codes.Unknown, "some error"),
+			output: status.New(codes.InvalidArgument, "some error"),
+		},
+		{
+			name: "Test-4",
+			input: NamespaceConfigError{
+				Message: "some error",
+				Type:    NamespaceUpdateFailedPrecondition,
+			},
+			output: status.New(codes.InvalidArgument, "some error"),
 		},
 	}
 


### PR DESCRIPTION
The changes herein disallow references in relation tuples to undefined relations in namespace configs. If a write is issued that references a relation that is undefined at that particular snapshot in time, an error is returned. Other changes include exponential retry-backoff for namespace monitoring and more appropriate error status responses.

closes #8
closes #14
closes #15