### PR TITLE
fix: eliminates the data race that was occurring with memberlist

### DIFF
--- a/internal/access-controller.go
+++ b/internal/access-controller.go
@@ -269,15 +269,6 @@ func NewAccessController(opts ...AccessControllerOption) (*AccessController, err
 	}
 	ac.Memberlist = list
 
-	meta, err := json.Marshal(NodeMetadata{
-		ServerPort: ac.ServerPort,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	list.LocalNode().Meta = meta
-
 	if ac.Join != "" {
 		joinAddrs := strings.Split(ac.Join, ",")
 
@@ -1022,7 +1013,15 @@ func (a *AccessController) ReadConfig(ctx context.Context, req *aclpb.ReadConfig
 //
 // For more information see https://pkg.go.dev/github.com/hashicorp/memberlist#Delegate
 func (a *AccessController) NodeMeta(limit int) []byte {
-	var meta []byte
+
+	meta, err := json.Marshal(NodeMetadata{
+		ServerPort: a.ServerPort,
+	})
+	if err != nil {
+		log.Errorf("Failed to json.Marshal this node's metadata: %v", err)
+		return nil
+	}
+
 	return meta
 }
 

--- a/internal/access-controller_test.go
+++ b/internal/access-controller_test.go
@@ -1768,6 +1768,28 @@ func TestAccessController_GetBroadcasts(t *testing.T) {
 	}
 }
 
+func TestAccessController_NodeMeta(t *testing.T) {
+
+	controller := AccessController{
+		NodeConfigs: NodeConfigs{
+			ServerPort: 50052,
+		},
+	}
+
+	expected, err := json.Marshal(NodeMetadata{
+		ServerPort: 50052,
+	})
+	if err != nil {
+		t.Fatalf("Failed to json.Marshal the expected NodeMetadata: %v", err)
+	}
+
+	meta := controller.NodeMeta(0)
+
+	if !reflect.DeepEqual(meta, expected) {
+		t.Errorf("Expected metadata '%s', but got '%s'", expected, meta)
+	}
+}
+
 func TestAccessController_watchNamespaceConfigs(t *testing.T) {
 
 	timestamp := time.Now()


### PR DESCRIPTION
The changes herein fix a data race that was occurring between the `AccessController` and the underlying Memberlist.