### PR TITLE
fix: resolve namespace cfg snapshot timestamps uniquly per namespace

### DIFF
--- a/internal/access-controller.go
+++ b/internal/access-controller.go
@@ -476,7 +476,7 @@ func (a *AccessController) check(ctx context.Context, namespace, object, relatio
 	// The namespace config timestamp from the peer should always be present if
 	// the request is proxied from another access-controller. If the request is
 	// made externally, we select a namespace config timestamp and forward it on.
-	peerNamespaceCfgTs, ok := NamespaceConfigTimestampFromContext(ctx)
+	peerNamespaceCfgTs, ok := NamespaceConfigTimestampFromContext(ctx, namespace)
 	if !ok {
 		snapshot, err := a.chooseNamespaceConfigSnapshot(namespace)
 		if err != nil {
@@ -492,7 +492,7 @@ func (a *AccessController) check(ctx context.Context, namespace, object, relatio
 
 		snapshotTimestamp = snapshot.Timestamp
 
-		ctx = NewContextWithNamespaceConfigTimestamp(ctx, snapshotTimestamp)
+		ctx = NewContextWithNamespaceConfigTimestamp(ctx, namespace, snapshotTimestamp)
 	} else {
 		snapshotTimestamp = peerNamespaceCfgTs
 	}
@@ -732,7 +732,7 @@ func (a *AccessController) expand(ctx context.Context, namespace, object, relati
 		return nil, nil
 	}
 
-	ctx = NewContextWithNamespaceConfigTimestamp(ctx, configSnapshot.Timestamp)
+	ctx = NewContextWithNamespaceConfigTimestamp(ctx, namespace, configSnapshot.Timestamp)
 
 	return a.expandWithRewrite(ctx, rewrite, tree, namespace, object, relation, depth)
 }

--- a/internal/namespace.go
+++ b/internal/namespace.go
@@ -66,17 +66,17 @@ var ErrNamespaceDoesntExist error = errors.New("the provided namespace doesn't e
 // and no local namespaces have been defined.
 var ErrNoLocalNamespacesDefined error = errors.New("no local namespace configs have been defined at this time")
 
-var nsConfigSnapshotTimestampKey ctxKey
+type nsConfigSnapshotTimestampKey string
 
-// NewContextWithNamespaceConfigTimestamp returns a new Context that carries the namespace config timestamp.
-func NewContextWithNamespaceConfigTimestamp(ctx context.Context, timestamp time.Time) context.Context {
-	return context.WithValue(ctx, nsConfigSnapshotTimestampKey, timestamp)
+// NewContextWithNamespaceConfigTimestamp returns a new Context that carries the namespace config name and timestamp.
+func NewContextWithNamespaceConfigTimestamp(ctx context.Context, namespace string, timestamp time.Time) context.Context {
+	return context.WithValue(ctx, nsConfigSnapshotTimestampKey(namespace), timestamp)
 }
 
 // NamespaceConfigTimestampFromContext extracts the snapshot timestamp for a namespace
 // configuration from the provided context. If none is present, a boolean false is returned.
-func NamespaceConfigTimestampFromContext(ctx context.Context) (time.Time, bool) {
-	timestamp, ok := ctx.Value(nsConfigSnapshotTimestampKey).(time.Time)
+func NamespaceConfigTimestampFromContext(ctx context.Context, namespace string) (time.Time, bool) {
+	timestamp, ok := ctx.Value(nsConfigSnapshotTimestampKey(namespace)).(time.Time)
 	return timestamp, ok
 }
 

--- a/internal/namespace_test.go
+++ b/internal/namespace_test.go
@@ -33,7 +33,14 @@ func TestNamespaceConfigTimestampFromContext(t *testing.T) {
 			},
 		},
 		{
-			input: NewContextWithNamespaceConfigTimestamp(context.Background(), ts),
+			input: NewContextWithNamespaceConfigTimestamp(context.Background(), "namespace2", ts),
+			output: output{
+				timestamp: time.Time{},
+				ok:        false,
+			},
+		},
+		{
+			input: NewContextWithNamespaceConfigTimestamp(context.Background(), "namespace1", ts),
 			output: output{
 				timestamp: ts,
 				ok:        true,
@@ -42,7 +49,7 @@ func TestNamespaceConfigTimestampFromContext(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		timestamp, ok := NamespaceConfigTimestampFromContext(test.input)
+		timestamp, ok := NamespaceConfigTimestampFromContext(test.input, "namespace1")
 
 		if ok != test.output.ok {
 			t.Errorf("Expected ok to be '%v', but got '%v'", test.output.ok, ok)


### PR DESCRIPTION
The changes herein ensure that namespace config snapshots are resolved and propagated uniquely per namespace. Namespace config changes can happen at different times between any two different namespaces, and therefore we must propagate the snapshot timestamps independently in the request context.

Fixes #36 .